### PR TITLE
Feature/avoid imread

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Requirements:
 - numpy
 - scipy
 - scikit-learn
+- Pillow
 
 To compute the FID or KID score between two datasets with features extracted from inception net:
 

--- a/fid_score.py
+++ b/fid_score.py
@@ -39,7 +39,7 @@ from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 import numpy as np
 import torch
 from scipy import linalg
-from scipy.misc import imread
+from PIL import Image
 from torch.nn.functional import adaptive_avg_pool2d
 
 try:
@@ -99,9 +99,8 @@ def get_activations(files, model, batch_size=50, dims=2048,
             images = np.copy(files[start:end]) + 1
             images /= 2.
         else:
-            images = np.array([imread(str(f)).astype(np.float32)
-                               for f in files[start:end]])
-            images /= 255.
+            images = [np.array(Image.open(str(f))) for f in files[start:end]]
+            images = np.stack(images).astype(np.float32) / 255.
             # Reshape to (n_images, 3, height, width)
             images = images.transpose((0, 3, 1, 2))
 

--- a/kid_score.py
+++ b/kid_score.py
@@ -296,7 +296,7 @@ if __name__ == '__main__':
                               'By default, uses pool3 features'))
     parser.add_argument('-c', '--gpu', default='', type=str,
                         help='GPU to use (leave blank for CPU only)')
-    parser.add_argument('--model, default='inception', type=str,
+    parser.add_argument('--model', default='inception', type=str,
                         help='inception or lenet')
     args = parser.parse_args()
     print(args)

--- a/kid_score.py
+++ b/kid_score.py
@@ -10,7 +10,7 @@ import numpy as np
 import torch
 from sklearn.metrics.pairwise import polynomial_kernel
 from scipy import linalg
-from scipy.misc import imread
+from PIL import Image
 from torch.nn.functional import adaptive_avg_pool2d
 
 try:
@@ -69,9 +69,8 @@ def get_activations(files, model, batch_size=50, dims=2048,
             images = np.copy(files[start:end]) + 1
             images /= 2.
         else:
-            images = np.array([imread(str(f)).astype(np.float32)
-                               for f in files[start:end]])
-            images /= 255.
+            images = [np.array(Image.open(str(f))) for f in files[start:end]]
+            images = np.stack(images).astype(np.float32) / 255.
             # Reshape to (n_images, 3, height, width)
             images = images.transpose((0, 3, 1, 2))
 


### PR DESCRIPTION
scipy.misc.imread has removed in scipy 1.3.0.
I modified to use Pillow.Image instead of imread.

And I fixed syntax error in kid_score.py.